### PR TITLE
Display included codes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,200 @@ If you would like to add a stopword or a new set of stopwords, please add them a
 ### Credits
 
 All stopwords sources are [listed here](https://github.com/stopwords-iso/stopwords-iso/blob/master/CREDITS.md).
+
+### List of Included Languages
+
+_Last updated: Tue Aug 20 16:26:44 2019_
+
+This table lists the entire set of ISO 639-1:2002 codes, with a check
+mark indicating those language codes that are found in `stopwords-iso.json`.
+
+The list of codes itself is from [www.loc.gov](http://www.loc.gov/standards/iso639-2/php/code_list.php), which is
+the official "language codes list" and is linked to from [www.iso.org](https://www.iso.org/iso-639-language-codes.html).
+
+| ISO 639-1 Code | Language | Included Here |
+| -------------- | -------- | ------------- |
+| aa | Afar |  |
+| ab | Abkhazian |  |
+| af | Afrikaans | ✓ |
+| ak | Akan |  |
+| sq | Albanian |  |
+| am | Amharic |  |
+| ar | Arabic | ✓ |
+| an | Aragonese |  |
+| hy | Armenian | ✓ |
+| as | Assamese |  |
+| av | Avaric |  |
+| ae | Avestan |  |
+| ay | Aymara |  |
+| az | Azerbaijani |  |
+| ba | Bashkir |  |
+| bm | Bambara |  |
+| eu | Basque | ✓ |
+| be | Belarusian |  |
+| bn | Bengali | ✓ |
+| bh | Bihari languages |  |
+| bi | Bislama |  |
+| bo | Tibetan |  |
+| bs | Bosnian |  |
+| br | Breton | ✓ |
+| bg | Bulgarian | ✓ |
+| my | Burmese |  |
+| ca | Catalan; Valencian | ✓ |
+| cs | Czech | ✓ |
+| ch | Chamorro |  |
+| ce | Chechen |  |
+| zh | Chinese | ✓ |
+| cu | Church Slavic; Old Slavonic; Church Slavonic; Old Bulgarian; Old Church Slavonic |  |
+| cv | Chuvash |  |
+| kw | Cornish |  |
+| co | Corsican |  |
+| cr | Cree |  |
+| cy | Welsh |  |
+| da | Danish | ✓ |
+| de | German | ✓ |
+| dv | Divehi; Dhivehi; Maldivian |  |
+| nl | Dutch; Flemish | ✓ |
+| dz | Dzongkha |  |
+| el | Greek, Modern (1453-) | ✓ |
+| en | English | ✓ |
+| eo | Esperanto | ✓ |
+| et | Estonian | ✓ |
+| ee | Ewe |  |
+| fo | Faroese |  |
+| fa | Persian | ✓ |
+| fj | Fijian |  |
+| fi | Finnish | ✓ |
+| fr | French | ✓ |
+| fy | Western Frisian |  |
+| ff | Fulah |  |
+| ka | Georgian |  |
+| gd | Gaelic; Scottish Gaelic |  |
+| ga | Irish | ✓ |
+| gl | Galician | ✓ |
+| gv | Manx |  |
+| gn | Guarani |  |
+| gu | Gujarati |  |
+| ht | Haitian; Haitian Creole |  |
+| ha | Hausa | ✓ |
+| he | Hebrew | ✓ |
+| hz | Herero |  |
+| hi | Hindi | ✓ |
+| ho | Hiri Motu |  |
+| hr | Croatian | ✓ |
+| hu | Hungarian | ✓ |
+| ig | Igbo |  |
+| is | Icelandic |  |
+| io | Ido |  |
+| ii | Sichuan Yi; Nuosu |  |
+| iu | Inuktitut |  |
+| ie | Interlingue; Occidental |  |
+| ia | Interlingua (International Auxiliary Language Association) |  |
+| id | Indonesian | ✓ |
+| ik | Inupiaq |  |
+| it | Italian | ✓ |
+| jv | Javanese |  |
+| ja | Japanese | ✓ |
+| kl | Kalaallisut; Greenlandic |  |
+| kn | Kannada |  |
+| ks | Kashmiri |  |
+| kr | Kanuri |  |
+| kk | Kazakh |  |
+| km | Central Khmer |  |
+| ki | Kikuyu; Gikuyu |  |
+| rw | Kinyarwanda |  |
+| ky | Kirghiz; Kyrgyz |  |
+| kv | Komi |  |
+| kg | Kongo |  |
+| ko | Korean | ✓ |
+| kj | Kuanyama; Kwanyama |  |
+| ku | Kurdish | ✓ |
+| lo | Lao |  |
+| la | Latin | ✓ |
+| lv | Latvian | ✓ |
+| li | Limburgan; Limburger; Limburgish |  |
+| ln | Lingala |  |
+| lt | Lithuanian | ✓ |
+| lb | Luxembourgish; Letzeburgesch |  |
+| lu | Luba-Katanga |  |
+| lg | Ganda |  |
+| mk | Macedonian |  |
+| mh | Marshallese |  |
+| ml | Malayalam |  |
+| mi | Maori |  |
+| mr | Marathi | ✓ |
+| ms | Malay | ✓ |
+| mg | Malagasy |  |
+| mt | Maltese |  |
+| mn | Mongolian |  |
+| na | Nauru |  |
+| nv | Navajo; Navaho |  |
+| nr | Ndebele, South; South Ndebele |  |
+| nd | Ndebele, North; North Ndebele |  |
+| ng | Ndonga |  |
+| ne | Nepali |  |
+| nn | Norwegian Nynorsk; Nynorsk, Norwegian |  |
+| nb | Bokmål, Norwegian; Norwegian Bokmål |  |
+| no | Norwegian | ✓ |
+| ny | Chichewa; Chewa; Nyanja |  |
+| oc | Occitan (post 1500) |  |
+| oj | Ojibwa |  |
+| or | Oriya |  |
+| om | Oromo |  |
+| os | Ossetian; Ossetic |  |
+| pa | Panjabi; Punjabi |  |
+| pi | Pali |  |
+| pl | Polish | ✓ |
+| pt | Portuguese | ✓ |
+| ps | Pushto; Pashto |  |
+| qu | Quechua |  |
+| rm | Romansh |  |
+| ro | Romanian; Moldavian; Moldovan | ✓ |
+| rn | Rundi |  |
+| ru | Russian | ✓ |
+| sg | Sango |  |
+| sa | Sanskrit |  |
+| si | Sinhala; Sinhalese |  |
+| sk | Slovak | ✓ |
+| sl | Slovenian | ✓ |
+| se | Northern Sami |  |
+| sm | Samoan |  |
+| sn | Shona |  |
+| sd | Sindhi |  |
+| so | Somali | ✓ |
+| st | Sotho, Southern | ✓ |
+| es | Spanish; Castilian | ✓ |
+| sc | Sardinian |  |
+| sr | Serbian |  |
+| ss | Swati |  |
+| su | Sundanese |  |
+| sw | Swahili | ✓ |
+| sv | Swedish | ✓ |
+| ty | Tahitian |  |
+| ta | Tamil |  |
+| tt | Tatar |  |
+| te | Telugu |  |
+| tg | Tajik |  |
+| tl | Tagalog | ✓ |
+| th | Thai | ✓ |
+| ti | Tigrinya |  |
+| to | Tonga (Tonga Islands) |  |
+| tn | Tswana |  |
+| ts | Tsonga |  |
+| tk | Turkmen |  |
+| tr | Turkish | ✓ |
+| tw | Twi |  |
+| ug | Uighur; Uyghur |  |
+| uk | Ukrainian | ✓ |
+| ur | Urdu | ✓ |
+| uz | Uzbek |  |
+| ve | Venda |  |
+| vi | Vietnamese | ✓ |
+| vo | Volapük |  |
+| wa | Walloon |  |
+| wo | Wolof |  |
+| xh | Xhosa |  |
+| yi | Yiddish |  |
+| yo | Yoruba | ✓ |
+| za | Zhuang; Chuang |  |
+| zu | Zulu | ✓ |

--- a/tabulate_codes.py
+++ b/tabulate_codes.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Generates a table of ISO 639-1:2002 and writes to README.md."""
+
+import json
+import time
+import os.path
+from html.parser import HTMLParser
+import urllib.request
+
+
+class ISO6391TableParser(HTMLParser):
+    def __init__(self, *args, **kwargs):
+        self._in_tr = self._in_td = self._code_flag = self._country_flag = False
+        self._reset_tdc()
+        self._codes = []
+        self._names = []
+        super().__init__(*args, **kwargs)
+
+    @property
+    def code_to_name(self):
+        if not hasattr(self, "_code_to_name"):
+            c2n = {}
+            for c, n in zip(self._codes, self._names):
+                if c.isalpha() and c.islower():
+                    c2n[c] = n
+            self._code_to_name = c2n
+        return self._code_to_name
+
+    def _reset_tdc(self):
+        self._tdc = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "tr":
+            self._in_tr = True
+            self._code_flag = self._country_flag = False
+        elif self._in_tr and tag == "td":
+            self._in_td = True
+            self._code_flag = self._tdc == 1
+            self._country_flag = self._tdc == 2
+            self._tdc += 1
+
+    def handle_endtag(self, tag):
+        if tag == "tr":
+            self._in_tr = False
+            self._reset_tdc()
+        elif tag == "td":
+            self._in_td = False
+
+    def handle_data(self, data):
+        if self._in_td:
+            if self._code_flag:
+                self._codes.append(data)
+            elif self._country_flag:
+                self._names.append(data)
+
+
+def tabulate():
+    url = "http://www.loc.gov/standards/iso639-2/php/code_list.php"
+    headers = {"User-Agent": "stopwords-iso/stopwords-iso"}
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req) as response:
+        html = response.read().decode("latin-1")
+
+    parser = ISO6391TableParser()
+    parser.feed(html)
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(here, "stopwords-iso.json")) as f:
+        sw = json.load(f)
+
+    lines = [
+        """\
+| ISO 639-1 Code | Language | Included Here |
+| -------------- | -------- | ------------- |"""
+    ]
+    check = "\u2713"
+    template = "| {code} | {lang} | {incl} |"
+    for k, v in parser.code_to_name.items():
+        lines.append(template.format(code=k, lang=v, incl=check if k in sw else ""))
+    with open(os.path.join(here, "README.md")) as f:
+        readme = f.read()
+    readme += """\
+
+### List of Included Languages
+
+_Last updated: {now}_
+
+This table lists the entire set of ISO 639-1:2002 codes, with a check
+mark indicating those language codes that are found in `stopwords-iso.json`.
+
+The list of codes itself is from [www.loc.gov](http://www.loc.gov/standards/iso639-2/php/code_list.php), which is
+the official "language codes list" and is linked to from [www.iso.org](https://www.iso.org/iso-639-language-codes.html).
+
+{table}
+""".format(
+        now=time.ctime(),
+        table="\n".join(lines)
+    )
+    with open(os.path.join(here, "README.md"), "w") as f:
+        return f.write(readme)
+
+
+if __name__ == "__main__":
+    tabulate()


### PR DESCRIPTION
Uses a Python 3 script, `tabulate_codes.py`, to
scrape the "official" codes table from
http://www.loc.gov/standards/iso639-2/php/code_list.php.

Cross-checks those codes against those found in
`stopwords-iso.json`.

Appends the resulting table to `README.md`.

Script has no external dependencies besides Python 3
standard library.